### PR TITLE
windows & Python 3.11 Py_IS_TYPE, Py_TYPE and PyObject_TypeCheck support

### DIFF
--- a/source/python/c.dpp
+++ b/source/python/c.dpp
@@ -42,9 +42,7 @@ auto pyTrue() {
     // FIXME:
     // This doesn't work as a manifest constant because there's a cast that the CTFE
     // engine doesn't like
-    //return Py_True;
-    // TODO: use Py_True instead, but it's apparently broken on windows
-    return PyBool_FromLong(1);
+    return Py_True;
 }
 
 // Demacroify
@@ -52,9 +50,7 @@ auto pyFalse() {
     // FIXME:
     // This doesn't work as a manifest constant because there's a cast that the CTFE
     // engine doesn't like
-    //return Py_False;
-    // TODO: use Py_False instead, but it's apparently broken on windows
-    return PyBool_FromLong(0);
+    return Py_False;
 }
 
 auto pyObjectNew(T)(PyTypeObject* typeobj) {
@@ -75,15 +71,4 @@ static int PyType_HasFeature(PyTypeObject *type, ulong feature) @safe @nogc pure
     return (flags & feature) != 0;
 }
 
-// static inline function in the header
-static int _Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) @safe @nogc pure nothrow {
-    return ob.ob_type == type;
-}
-
-// the check is here since this doesn't exist in Python 3.8
-static if(is(typeof(Py_IS_TYPE(null, null)))) {
-    // copied from 3.10 object.h
-    private int _PyObject_TypeCheck(PyObject *ob, PyTypeObject *type) @trusted nothrow {
-        return Py_IS_TYPE(ob, type) || PyType_IsSubtype(( ( cast( PyObject * ) ( ob ) ) . ob_type ), type);
-    }
-}
+public import python.statics;

--- a/source/python/statics.d
+++ b/source/python/statics.d
@@ -1,0 +1,26 @@
+/// Separate module to not accidentally run the preprocessor on these methods
+module python.statics;
+
+import python.c;
+
+extern(C):
+
+// static inline function in the header
+int Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) @safe @nogc pure nothrow {
+    return ob.ob_type == type;
+}
+
+PyTypeObject* Py_TYPE_(PyObject *ob) @safe @nogc pure nothrow {
+    return ob.ob_type;
+}
+
+// the check is here since this doesn't exist in Python 3.8
+static if(is(typeof(Py_IS_TYPE(null, null)))) {
+    // copied from 3.10 object.h
+    int PyObject_TypeCheck_(PyObject *ob, PyTypeObject *type) @trusted nothrow {
+        return Py_IS_TYPE(ob, type) || PyType_IsSubtype(( ( cast( PyObject * ) ( ob ) ) . ob_type ), type);
+    }
+
+    // translation fails here still
+    alias PyObject_TypeCheck = PyObject_TypeCheck_;
+}

--- a/translate.bat
+++ b/translate.bat
@@ -27,6 +27,6 @@ echo name "_helper"; targetType "sourceLibrary"; lflags `/LIBPATH:%PYTHON_INCLUD
 
 IF NOT EXIST "%PYTHON_INCLUDE_PATH%\..\libs\python3.lib" echo WARNING: %PYTHON_INCLUDE_PATH%\..\libs\python3.lib does not exist, linking may fail!
 
-dub run dpp@0.5.1 --build=release -- --ignore-cursor=stat64 --ignore-cursor=PyType_HasFeature --ignore-cursor=_Py_IS_TYPE  --ignore-cursor=_PyObject_TypeCheck --ignore-cursor=COMPILER --ignore-cursor=_PyCode_DEF --ignore-cursor=Py_IS_TYPE --function-macros --preprocess-only --include-path "%PYTHON_INCLUDE_PATH%" "%IFILE%"
+dub run dpp@0.5.4 --build=release -- --ignore-cursor=stat64 --ignore-cursor=PyType_HasFeature --ignore-cursor=_Py_IS_TYPE  --ignore-cursor=_PyObject_TypeCheck --ignore-cursor=COMPILER --ignore-cursor=_PyCode_DEF --ignore-cursor=Py_IS_TYPE --function-macros --preprocess-only --include-path "%PYTHON_INCLUDE_PATH%" "%IFILE%"
 
 :END

--- a/translate.sh
+++ b/translate.sh
@@ -30,5 +30,5 @@ fi
 if [[ ! -f $o || $i -nt $o ]]; then
     PYTHON_INCLUDE_PATH=$(python3 "$PACKAGE_DIR"/include.py)
     echo "Translating Python headers in $PYTHON_INCLUDE_PATH"
-    CC="$clinker" dub run dpp@0.5.1 --build=release -- --ignore-cursor=stat64 --ignore-cursor=PyType_HasFeature --ignore-cursor=_Py_IS_TYPE  --ignore-cursor=_PyObject_TypeCheck --function-macros --preprocess-only --include-path "$PYTHON_INCLUDE_PATH" "$i"
+    CC="$clinker" dub run dpp@0.5.4 --build=release -- --ignore-cursor=stat64 --ignore-cursor=PyType_HasFeature --ignore-cursor=_Py_IS_TYPE  --ignore-cursor=_PyObject_TypeCheck --function-macros --preprocess-only --include-path "$PYTHON_INCLUDE_PATH" "$i"
 fi


### PR DESCRIPTION
needs dpp from https://github.com/atilaneves/dpp/pull/337 for full support

lucky: the true/false workarounds are no longer needed with the newest dpp version