### PR TITLE
emit warning on failure on old clang

### DIFF
--- a/translate.sh
+++ b/translate.sh
@@ -27,7 +27,18 @@ else
     exit 1
 fi
 
+function warn_old_clang {
+    CLANG_VER="$(clang --version | head -n1)"
+    if [[ "$CLANG_VER" =~ [Cc]lang\ [Vv]ersion\ (5|6|7|8|9|10|11) ]]; then
+        echo "Your clang version appears to be quite old, errors in translation might be fixed by upgrading your clang version to at least clang 12 or newer."
+        echo "If you have newer clang versions installed in parallel, try uninstalling the older ones or symlinking the newer one to 'clang'."
+        echo "$CLANG_VER"
+    fi
+}
+
 if [[ ! -f $o || $i -nt $o ]]; then
+    trap warn_old_clang ERR
+
     PYTHON_INCLUDE_PATH=$(python3 "$PACKAGE_DIR"/include.py)
     echo "Translating Python headers in $PYTHON_INCLUDE_PATH"
     CC="$clinker" dub run dpp@0.5.5 --build=release -- --ignore-cursor=stat64 --ignore-cursor=PyType_HasFeature --ignore-cursor=_Py_IS_TYPE  --ignore-cursor=_PyObject_TypeCheck --function-macros --preprocess-only --include-path "$PYTHON_INCLUDE_PATH" "$i"


### PR DESCRIPTION
sample output:

```
...
/usr/include/python3.8/unicodeobject.h:103:9: error: unknown type name 'uint16_t'
/usr/include/python3.8/unicodeobject.h:104:9: error: unknown type name 'uint8_t'
/usr/include/python3.8/longintrepr.h:45:9: error: unknown type name 'uint32_t'
/usr/include/python3.8/longintrepr.h:47:9: error: unknown type name 'uint64_t'
/usr/include/python3.8/cpython/dictobject.h:22:5: error: unknown type name 'uint64_t'
fatal error: too many errors emitted, stopping now
Program exited with code 1
Your clang version appears to be quite old, errors in translation might be fixed by upgrading your clang version to at least clang 12 or newer.
If you have newer clang versions installed in parallel, try uninstalling the older ones or symlinking the newer one to 'clang'.
clang version 10.0.0-4ubuntu1 
```

for me on Ubuntu 20 this was fixed by uninstalling the clang package, instead installing clang-12 and libclang-12-dev, as well as doing `sudo ln -s /usr/bin/clang-12 /usr/local/bin/clang`